### PR TITLE
Add basic tests with coverage workflow

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -33,7 +33,7 @@ jobs:
           coverage run -m pytest
           coverage xml
       - name: Upload coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.xml

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,39 @@
+name: Python Tests
+
+on:
+  push:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'requirements.txt'
+      - '.github/workflows/python-tests.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'requirements.txt'
+      - '.github/workflows/python-tests.yml'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests with coverage
+        run: |
+          pip install coverage
+          coverage run -m pytest
+          coverage xml
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ coverage_report/
 *.cover
 trace_report.dat
 .pytest_cache/
+.coverage
+coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ frontend/build/
 .env
 .vite/
 timed_task/log/
-tests/*/*
 volumes/
 *.log
+
+# Test artifacts
+coverage_report/
+*.cover
+trace_report.dat
+.pytest_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ trace_report.dat
 .pytest_cache/
 .coverage
 coverage.xml
+trace_output/

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+from .helpers import openai_stub, redis_stub, tenacity_stub, dotenv_stub  # noqa: F401

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,11 @@
-from .helpers import openai_stub, redis_stub, tenacity_stub, dotenv_stub  # noqa: F401
+from .helpers import (
+    openai_stub,
+    redis_stub,
+    tenacity_stub,
+    dotenv_stub,
+    pdf2image_stub,
+    asgiref_sync_stub,
+    markitdown_stub,
+    firecrawl_stub,
+    base_handler_stub,
+)  # noqa: F401

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -2,3 +2,8 @@ from .openai_stub import *  # noqa: F401,F403
 from .redis_stub import *  # noqa: F401,F403
 from .tenacity_stub import *  # noqa: F401,F403
 from .dotenv_stub import *  # noqa: F401,F403
+from .pdf2image_stub import *  # noqa: F401,F403
+from .asgiref_sync_stub import *  # noqa: F401,F403
+from .markitdown_stub import *  # noqa: F401,F403
+from .firecrawl_stub import *  # noqa: F401,F403
+from .base_handler_stub import *  # noqa: F401,F403

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,4 @@
+from .openai_stub import *  # noqa: F401,F403
+from .redis_stub import *  # noqa: F401,F403
+from .tenacity_stub import *  # noqa: F401,F403
+from .dotenv_stub import *  # noqa: F401,F403

--- a/tests/helpers/asgiref_sync_stub.py
+++ b/tests/helpers/asgiref_sync_stub.py
@@ -1,0 +1,14 @@
+import sys, types
+
+asgiref_mod = types.ModuleType('asgiref')
+sync_mod = types.ModuleType('asgiref.sync')
+
+async def sync_to_async(fn):
+    async def wrapper(*args, **kwargs):
+        return fn(*args, **kwargs)
+    return wrapper
+
+sync_mod.sync_to_async = sync_to_async
+
+sys.modules['asgiref'] = asgiref_mod
+sys.modules['asgiref.sync'] = sync_mod

--- a/tests/helpers/base_handler_stub.py
+++ b/tests/helpers/base_handler_stub.py
@@ -1,0 +1,11 @@
+import sys, types
+
+mod = types.ModuleType('src.backend.sitesearch.handler.base_handler')
+class BaseHandler: 
+    pass
+class ComponentStatus:
+    STOPPED = 'stopped'
+    RUNNING = 'running'
+mod.BaseHandler = BaseHandler
+mod.ComponentStatus = ComponentStatus
+sys.modules['src.backend.sitesearch.handler.base_handler'] = mod

--- a/tests/helpers/dotenv_stub.py
+++ b/tests/helpers/dotenv_stub.py
@@ -1,0 +1,10 @@
+import sys, types
+
+dotenv_mod = types.ModuleType('dotenv')
+
+def load_dotenv(*args, **kwargs):
+    return None
+
+dotenv_mod.load_dotenv = load_dotenv
+
+sys.modules['dotenv'] = dotenv_mod

--- a/tests/helpers/firecrawl_stub.py
+++ b/tests/helpers/firecrawl_stub.py
@@ -1,0 +1,26 @@
+import sys, types
+
+firecrawl_mod = types.ModuleType('firecrawl')
+sub_mod = types.ModuleType('firecrawl.firecrawl')
+
+class FirecrawlApp:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class ScrapeOptions: ...
+class CrawlStatusResponse: ...
+class FirecrawlDocument: ...
+class CrawlResponse: ...
+class ScrapeResponse: ...
+
+sub_mod.FirecrawlApp = FirecrawlApp
+sub_mod.ScrapeOptions = ScrapeOptions
+sub_mod.CrawlStatusResponse = CrawlStatusResponse
+sub_mod.FirecrawlDocument = FirecrawlDocument
+sub_mod.CrawlResponse = CrawlResponse
+sub_mod.ScrapeResponse = ScrapeResponse
+
+firecrawl_mod.firecrawl = sub_mod
+
+sys.modules['firecrawl'] = firecrawl_mod
+sys.modules['firecrawl.firecrawl'] = sub_mod

--- a/tests/helpers/markitdown_stub.py
+++ b/tests/helpers/markitdown_stub.py
@@ -1,0 +1,11 @@
+import sys, types
+
+mod = types.ModuleType('markitdown')
+class MarkItDown:
+    def convert(self, path):
+        class Result:
+            text_content = ""
+        return Result()
+
+mod.MarkItDown = MarkItDown
+sys.modules['markitdown'] = mod

--- a/tests/helpers/openai_stub.py
+++ b/tests/helpers/openai_stub.py
@@ -1,0 +1,17 @@
+import sys, types
+
+openai_mod = types.ModuleType('openai')
+openai_types = types.ModuleType('openai.types')
+chat_mod = types.ModuleType('openai.types.chat')
+
+class AsyncOpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+
+setattr(chat_mod, 'ChatCompletionMessageParam', dict)
+openai_mod.AsyncOpenAI = AsyncOpenAI
+openai_mod.types = types.SimpleNamespace(chat=chat_mod)
+
+sys.modules['openai'] = openai_mod
+sys.modules['openai.types'] = openai_types
+sys.modules['openai.types.chat'] = chat_mod

--- a/tests/helpers/openai_stub.py
+++ b/tests/helpers/openai_stub.py
@@ -8,8 +8,13 @@ class AsyncOpenAI:
     def __init__(self, *args, **kwargs):
         pass
 
+class OpenAI:
+    def __init__(self, *args, **kwargs):
+        pass
+
 setattr(chat_mod, 'ChatCompletionMessageParam', dict)
 openai_mod.AsyncOpenAI = AsyncOpenAI
+openai_mod.OpenAI = OpenAI
 openai_mod.types = types.SimpleNamespace(chat=chat_mod)
 
 sys.modules['openai'] = openai_mod

--- a/tests/helpers/pdf2image_stub.py
+++ b/tests/helpers/pdf2image_stub.py
@@ -1,0 +1,9 @@
+import sys, types
+
+pdf2image_mod = types.ModuleType('pdf2image')
+
+def convert_from_path(path):
+    return []
+
+pdf2image_mod.convert_from_path = convert_from_path
+sys.modules['pdf2image'] = pdf2image_mod

--- a/tests/helpers/redis_stub.py
+++ b/tests/helpers/redis_stub.py
@@ -1,0 +1,28 @@
+import sys, types
+from unittest.mock import MagicMock
+
+redis_mod = types.ModuleType('redis')
+
+class Pipeline:
+    def __enter__(self):
+        return self
+    def __exit__(self, exc_type, exc, tb):
+        pass
+    def set(self, *args, **kwargs):
+        pass
+    def lpush(self, *args, **kwargs):
+        pass
+    def hincrby(self, *args, **kwargs):
+        pass
+    def execute(self):
+        pass
+
+class RedisClient:
+    def pipeline(self):
+        return Pipeline()
+
+def from_url(url):
+    return RedisClient()
+
+redis_mod.from_url = from_url
+sys.modules['redis'] = redis_mod

--- a/tests/helpers/tenacity_stub.py
+++ b/tests/helpers/tenacity_stub.py
@@ -1,0 +1,20 @@
+import sys, types
+
+tenacity_mod = types.ModuleType('tenacity')
+
+def retry(*dargs, **dkwargs):
+    def wrapper(fn):
+        return fn
+    return wrapper
+
+def stop_after_attempt(*args, **kwargs):
+    return None
+
+def wait_exponential(*args, **kwargs):
+    return None
+
+tenacity_mod.retry = retry
+tenacity_mod.stop_after_attempt = stop_after_attempt
+tenacity_mod.wait_exponential = wait_exponential
+
+sys.modules['tenacity'] = tenacity_mod

--- a/tests/test_analyzer.py
+++ b/tests/test_analyzer.py
@@ -1,0 +1,37 @@
+import types
+import importlib.util
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+import asyncio
+
+from tests.helpers import openai_stub  # noqa: F401
+
+module_path = Path(__file__).resolve().parents[1] / 'src/backend/sitesearch/agent/analyzer.py'
+spec = importlib.util.spec_from_file_location('analyzer', module_path)
+analyzer_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(analyzer_mod)
+Analyzer = analyzer_mod.Analyzer
+AnalyzerPrompt = analyzer_mod.AnalyzerPrompt
+
+
+class DummyClient:
+    def __init__(self, content: str):
+        class _Completions:
+            async def create(self_inner, *args, **kwargs):
+                return types.SimpleNamespace(choices=[types.SimpleNamespace(message=types.SimpleNamespace(content=content))])
+        self.chat = types.SimpleNamespace(completions=_Completions())
+
+
+def test_analyze_basic():
+    client = DummyClient("one\ntwo\nthree")
+    analyzer = Analyzer(client, model='dummy')
+    result = asyncio.run(analyzer.analyze("hi", AnalyzerPrompt.CONTEXT_PROMPT, item_count=2))
+    assert result == ["one", "two", "three"]
+
+
+def test_analyze_kmds():
+    client = DummyClient("unused")
+    analyzer = Analyzer(client)
+    with patch.object(Analyzer, 'analyze', new=AsyncMock(side_effect=[["k"], ["m"], ["d"], ["s"]])):
+        results = asyncio.run(analyzer.analyze_kmds("q", item_count=1))
+    assert results == [["k"], ["m"], ["d"], ["s"]]

--- a/tests/test_file_markdown_tool.py
+++ b/tests/test_file_markdown_tool.py
@@ -1,0 +1,26 @@
+from PIL import Image
+from src.backend.tools.file_markdown_tool import split_image
+
+
+def create_image(width, height):
+    return Image.new('RGB', (width, height), color='white')
+
+
+def test_split_image_no_split():
+    img = create_image(100, 100)
+    result = split_image(img, max_height=200, max_width=200)
+    assert len(result) == 1
+
+
+def test_split_image_vertical():
+    img = create_image(100, 500)
+    result = split_image(img, max_height=200, max_width=200)
+    assert len(result) == 3  # ceil(500/200)
+    assert all(im.size[0] == 100 for im in result)
+
+
+def test_split_image_horizontal():
+    img = create_image(500, 100)
+    result = split_image(img, max_height=200, max_width=200)
+    assert len(result) == 3
+    assert all(im.size[1] == 100 for im in result)

--- a/tests/test_handler_factory.py
+++ b/tests/test_handler_factory.py
@@ -1,0 +1,54 @@
+import sys, types
+import importlib.util
+from unittest.mock import MagicMock, patch
+from pathlib import Path
+
+# Stub handler modules to avoid heavy dependencies
+for cls_name in ["crawler_handler", "cleaner_handler", "storage_handler", "indexer_handler"]:
+    module_name = f"src.backend.sitesearch.handler.{cls_name}"
+    mod = types.ModuleType(module_name)
+    handler_cls = type(cls_name.title().replace('_', ''), (), {})
+    setattr(mod, handler_cls.__name__, handler_cls)
+    sys.modules[module_name] = mod
+
+spec = importlib.util.spec_from_file_location(
+    "src.backend.sitesearch.handler.handler_factory",
+    Path(__file__).resolve().parents[1] / 'src/backend/sitesearch/handler/handler_factory.py'
+)
+handler_factory = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = handler_factory
+spec.loader.exec_module(handler_factory)
+HandlerFactory = handler_factory.HandlerFactory
+
+
+def setup_function(func):
+    HandlerFactory._handlers = {}
+
+
+@patch('src.backend.sitesearch.handler.handler_factory.CrawlerHandler')
+def test_create_crawler_singleton(mock_crawler):
+    instance = MagicMock(name='crawler')
+    mock_crawler.return_value = instance
+    h1 = HandlerFactory.create_crawler_handler('redis://local', handler_id='c1')
+    h2 = HandlerFactory.create_crawler_handler('redis://local', handler_id='c1')
+    assert h1 is h2
+    mock_crawler.assert_called_once()
+
+
+@patch('src.backend.sitesearch.handler.handler_factory.IndexerHandler')
+@patch('src.backend.sitesearch.handler.handler_factory.StorageHandler')
+@patch('src.backend.sitesearch.handler.handler_factory.CleanerHandler')
+@patch('src.backend.sitesearch.handler.handler_factory.CrawlerHandler')
+def test_create_complete_pipeline(mock_crawler, mock_cleaner, mock_storage, mock_indexer):
+    mock_crawler.return_value = MagicMock(name='crawler')
+    mock_cleaner.return_value = MagicMock(name='cleaner')
+    mock_storage.return_value = MagicMock(name='storage')
+    mock_indexer.return_value = MagicMock(name='indexer')
+
+    pipeline = HandlerFactory.create_complete_pipeline('redis://r', 'milvus://m', prefix='t', auto_start=False)
+
+    assert set(pipeline.keys()) == {'crawler', 'cleaner', 'storage', 'indexer'}
+    mock_crawler.assert_called_once()
+    mock_cleaner.assert_called_once()
+    mock_storage.assert_called_once()
+    mock_indexer.assert_called_once()

--- a/tests/test_json_tools.py
+++ b/tests/test_json_tools.py
@@ -1,0 +1,36 @@
+import asyncio
+import json
+
+from src.backend.tools.json_tools import format_as_ndjson, JSONEncoder_with_dataclasses
+
+async def async_gen(n):
+    for i in range(n):
+        yield {"num": i}
+
+
+def test_format_as_ndjson_basic():
+    async def collect():
+        lines = []
+        async for line in format_as_ndjson(async_gen(2)):
+            lines.append(line)
+        return lines
+    lines = asyncio.run(collect())
+    assert lines == [
+        json.dumps({"num": 0}, ensure_ascii=False, cls=JSONEncoder_with_dataclasses) + "\n",
+        json.dumps({"num": 1}, ensure_ascii=False, cls=JSONEncoder_with_dataclasses) + "\n",
+    ]
+
+
+async def error_gen():
+    yield {"a": 1}
+    raise ValueError("oops")
+
+
+def test_format_as_ndjson_error():
+    async def collect():
+        lines = []
+        async for line in format_as_ndjson(error_gen()):
+            lines.append(line)
+        return lines
+    lines = asyncio.run(collect())
+    assert lines[-1] == json.dumps({"error": "oops"})

--- a/tests/test_markdown_tools.py
+++ b/tests/test_markdown_tools.py
@@ -1,0 +1,17 @@
+import pytest
+from src.backend.tools.markdown_tools import parse_links, replace_base64, clean_md
+
+
+def test_parse_links():
+    text = "This [link](http://example.com) and ![img](image.png)"
+    assert parse_links(text) == ["http://example.com", "image.png"]
+
+
+def test_replace_base64():
+    content = "![pic](data:image/png;base64,xxxx)"
+    assert replace_base64(content) == "![pic](base64_image)"
+
+
+def test_clean_md():
+    raw = " line1  \n\n![i](data:image/jpeg;base64,abc)\n  line2   "
+    assert clean_md(raw) == "line1\n\nline2"

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,55 @@
+import json
+from pathlib import Path
+import importlib.util
+
+from tests.helpers import openai_stub  # noqa: F401
+
+# Load Optimizer without importing package __init__
+module_path = Path(__file__).resolve().parents[1] / 'src/backend/sitesearch/agent/optimizer.py'
+spec = importlib.util.spec_from_file_location('optimizer', module_path)
+optimizer_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(optimizer_mod)
+Optimizer = optimizer_mod.Optimizer
+
+
+def create_hint_file(tmp_path: Path):
+    data = {
+        "AI": {
+            "full_name": "Artificial Intelligence",
+            "translation": "\u4eba\u5de5\u667a\u80fd",
+            "remarks": ""
+        },
+        "NLP": {
+            "full_name": "Natural Language Processing",
+            "translation": "\u81ea\u7136\u8bed\u8a00\u5904\u7406",
+            "remarks": "remark"
+        }
+    }
+    file_path = tmp_path / "hint_table.json"
+    with open(file_path, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+    return file_path
+
+
+def test_get_hint(tmp_path):
+    hint_file = create_hint_file(tmp_path)
+    opt = Optimizer(hint_table_path=str(hint_file))
+    hint = opt._get_hint("This talks about AI and nothing else")
+    expected = (
+        "Hint for specific terms:\n"
+        "- AI stands for Artificial Intelligence and \u4eba\u5de5\u667a\u80fd in Chinese."
+    )
+    assert hint.strip() == expected
+
+
+def test_get_hint_none(tmp_path):
+    hint_file = create_hint_file(tmp_path)
+    opt = Optimizer(hint_table_path=str(hint_file))
+    assert opt._get_hint("Nothing here") == ""
+
+
+def test_optimize(tmp_path):
+    hint_file = create_hint_file(tmp_path)
+    opt = Optimizer(hint_table_path=str(hint_file))
+    message = [{"role": "user", "content": "Tell me about AI"}]
+    assert "Artificial Intelligence" in opt.optimize(message)

--- a/tests/test_pipeline_manager_utils.py
+++ b/tests/test_pipeline_manager_utils.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+from src.backend.sitesearch.pipeline_manager import MultiProcessSiteSearchManager
+
+
+@patch('src.backend.sitesearch.pipeline_manager.redis.from_url')
+def test_update_last_activity(mock_from_url):
+    client = MagicMock(delete=lambda *a, **k: None)
+    mock_from_url.return_value = client
+    mgr = MultiProcessSiteSearchManager('redis://local')
+    mgr.redis_client = MagicMock()  # avoid calls from setup_queues interfering
+    mgr.update_last_activity('crawler')
+    mgr.redis_client.set.assert_called_once()
+    key, value = mgr.redis_client.set.call_args[0]
+    assert key == 'sitesearch:last_activity:crawler'
+    assert float(value) == float(value)  # value is timestamp string
+
+
+@patch('src.backend.sitesearch.pipeline_manager.redis.from_url')
+def test_record_processing_time(mock_from_url):
+    client = MagicMock(delete=lambda *a, **k: None)
+    mock_from_url.return_value = client
+    mgr = MultiProcessSiteSearchManager('redis://local')
+    mgr.redis_client = MagicMock()
+    mgr.record_processing_time('cleaner', 1.5)
+    mgr.redis_client.lpush.assert_called_once_with('sitesearch:processing_times:cleaner', '1.5')
+    mgr.redis_client.ltrim.assert_called_once_with('sitesearch:processing_times:cleaner', 0, 99)

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -1,0 +1,16 @@
+from unittest.mock import MagicMock, patch
+
+from tests.helpers import redis_stub  # noqa: F401
+from src.backend.sitesearch.utils.queue_manager import QueueManager
+
+
+@patch('src.backend.sitesearch.utils.queue_manager.redis.from_url')
+def test_key_generation(mock_from_url):
+    mock_from_url.return_value = MagicMock()
+    manager = QueueManager('redis://localhost:6379')
+    assert manager._get_queue_key('q') == 'sitesearch:queue:q'
+    assert manager._get_processing_key('q') == 'sitesearch:processing:q'
+    assert manager._get_completed_key('q') == 'sitesearch:completed:q'
+    assert manager._get_failed_key('q') == 'sitesearch:failed:q'
+    assert manager._get_task_meta_key('t') == 'sitesearch:task:meta:t'
+    assert manager._get_stats_key('q') == 'sitesearch:stats:q'

--- a/tests/test_queue_manager.py
+++ b/tests/test_queue_manager.py
@@ -14,3 +14,12 @@ def test_key_generation(mock_from_url):
     assert manager._get_failed_key('q') == 'sitesearch:failed:q'
     assert manager._get_task_meta_key('t') == 'sitesearch:task:meta:t'
     assert manager._get_stats_key('q') == 'sitesearch:stats:q'
+
+@patch('src.backend.sitesearch.utils.queue_manager.redis.from_url')
+def test_get_queue_manager_singleton(mock_from_url):
+    mock_from_url.return_value = MagicMock(llen=lambda k: 0, hgetall=lambda k: {})
+    import src.backend.sitesearch.utils.queue_manager as qm
+    qm._queue_manager_instance = None
+    first = qm.get_queue_manager('redis://1')
+    second = qm.get_queue_manager('redis://2')
+    assert first is second

--- a/tests/test_queue_manager_ops.py
+++ b/tests/test_queue_manager_ops.py
@@ -1,0 +1,19 @@
+from unittest.mock import MagicMock, patch
+from tests.helpers import redis_stub  # noqa: F401
+from src.backend.sitesearch.utils.queue_manager import QueueManager
+
+
+@patch('src.backend.sitesearch.utils.queue_manager.redis.from_url')
+def test_simple_operations(mock_from_url):
+    client = MagicMock()
+    client.llen.return_value = 5
+    client.get.return_value = b'{"id": "t1"}'
+    client.hgetall.return_value = {b'pending': b'2', b'processing': b'1', b'completed': b'3', b'failed': b'0', b'total_processing_time': b'6'}
+    mock_from_url.return_value = client
+
+    qm = QueueManager('redis://local')
+    assert qm.get_queue_length('q') == 5
+    assert qm.get_task_status('t1') == {"id": "t1"}
+    metrics = qm.get_queue_metrics('q')
+    assert metrics.pending_tasks == 2
+    assert metrics.avg_processing_time == 2.0  # 6 / 3

--- a/tests/test_queue_monitor.py
+++ b/tests/test_queue_monitor.py
@@ -1,0 +1,40 @@
+from unittest.mock import MagicMock
+import importlib
+from src.backend.sitesearch.utils.queue_manager import QueueMetrics
+
+import src.backend.sitesearch.utils.queue_monitor as qm
+
+
+def setup_function(func):
+    qm._queue_monitor_instance = None
+
+
+def teardown_function(func):
+    qm._queue_monitor_instance = None
+
+
+def test_get_queue_monitor_singleton(monkeypatch):
+    dummy_qm = MagicMock()
+    monkeypatch.setattr(qm, 'get_queue_manager', lambda: dummy_qm)
+    monitor1 = qm.get_queue_monitor(queue_names=['q1'])
+    monitor2 = qm.get_queue_monitor(queue_names=['q2'])
+    assert monitor1 is monitor2
+    assert monitor1.queue_names == ['q1']
+
+
+def test_summary_report(monkeypatch):
+    metrics = {
+        'q1': QueueMetrics(queue_name='q1', pending_tasks=1, completed_tasks=1),
+        'q2': QueueMetrics(queue_name='q2', pending_tasks=2001, completed_tasks=1, failed_tasks=2),
+    }
+    dummy = MagicMock()
+    dummy.get_queue_metrics.side_effect = lambda name: metrics[name]
+    monkeypatch.setattr(qm, 'get_queue_manager', lambda: dummy)
+    monitor = qm.get_queue_monitor(queue_names=['q1', 'q2'], max_pending_threshold=1000, max_error_rate=0.1)
+    monitor._check_queue_health('q1')
+    monitor._check_queue_health('q2')
+    report = monitor.get_summary_report()
+    assert report['total_queues'] == 2
+    assert report['unhealthy_queues'] == 1
+    assert report['total_pending_tasks'] == 2002
+    assert any(d['name'] == 'q2' for d in report['unhealthy_details'])


### PR DESCRIPTION
## Summary
- add helper stubs for `openai` and `redis` to make unit tests self contained
- add tests for Optimizer and QueueManager
- ignore test artifacts in `.gitignore`
- add GitHub Actions workflow to run tests and generate coverage

## Testing
- `pytest -q`
- `python -m trace --count --file trace_report.dat --no-report --module pytest -q`
- `python -m trace --report --summary -f trace_report.dat | grep 'src/backend' | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_68413e394ce483259850ebcaf56aa027